### PR TITLE
Schema updates

### DIFF
--- a/tools/dvrescue.xsd
+++ b/tools/dvrescue.xsd
@@ -104,7 +104,7 @@
   </xsd:complexType>
 
   <xsd:complexType name="staType">
-    <xsd:attribute name="t" type="xsd:string">
+    <xsd:attribute name="t" type="xsd:integer">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Documents a type of non-zero STA value present in the frame (see table 26 of s314m). For convenience:

--- a/tools/dvrescue.xsd
+++ b/tools/dvrescue.xsd
@@ -46,7 +46,10 @@
     </xsd:sequence>
     <xsd:attribute name="size" type="xsd:string"/>
     <xsd:attribute name="video_rate" type="xsd:string"/>
+    <xsd:attribute name="chroma_subsampling" type="xsd:string"/>
     <xsd:attribute name="aspect_ratio" type="xsd:string"/>
+    <xsd:attribute name="sample_rate" type="xsd:integer"/>
+    <xsd:attribute name="channels" type="xsd:integer"/>
   </xsd:complexType>
 
   <xsd:complexType name="frameType">

--- a/tools/dvrescue.xsd
+++ b/tools/dvrescue.xsd
@@ -130,5 +130,12 @@
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
+    <xsd:attribute name="n_even" type="xsd:integer">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          A count of this particular type of STA value within the even-numbered DIF sequences of the frame. @n minus @n_even would provide the count of this particular type of STA value within the odd-numbered DIF sequences of the frame. A discrepancy between the counts within even and odd DIF sequences can indicate that the associated error is from the playback device of the source tape rather than damage to the source tape. The range is 0-675 for NTSC DV25 and 0-810 for PAL DV25.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
   </xsd:complexType>
 </xsd:schema>

--- a/tools/dvrescue.xsd
+++ b/tools/dvrescue.xsd
@@ -143,7 +143,7 @@
   </xsd:complexType>
 
   <xsd:complexType name="audType">
-    <xsd:attribute name="t" type="xsd:integer">
+    <xsd:attribute name="t" type="xsd:integer" default="1">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Documents the type of audio errors within the frame.

--- a/tools/dvrescue.xsd
+++ b/tools/dvrescue.xsd
@@ -56,6 +56,7 @@
     <xsd:sequence>
       <xsd:element name="dseq" type="dseqType" minOccurs="0" maxOccurs="unbounded"/>
       <xsd:element name="sta" type="staType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="aud" type="audType" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
     <xsd:attribute name="n" type="xsd:integer"/>
     <xsd:attribute name="pts" type="xsd:string"/>
@@ -75,6 +76,7 @@
     <xsd:sequence>
       <xsd:element name="sct" type="sctType" minOccurs="0" maxOccurs="unbounded"/>
       <xsd:element name="sta" type="staType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="aud" type="audType" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
     <xsd:attribute name="n" type="xsd:integer">
       <xsd:annotation>
@@ -88,6 +90,7 @@
   <xsd:complexType name="sctType">
     <xsd:sequence>
       <xsd:element name="sta" type="staType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="aud" type="staType" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
     <xsd:attribute name="t" type="xsd:integer">
       <xsd:annotation>
@@ -138,4 +141,30 @@
       </xsd:annotation>
     </xsd:attribute>
   </xsd:complexType>
+
+  <xsd:complexType name="audType">
+    <xsd:attribute name="t" type="xsd:integer">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Documents the type of audio errors within the frame.
+          1 = An audio DIF block is filled with 0x8000 which indicates an invalid audio sample.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="n" type="xsd:integer">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          A count of this particular type of audio error within the frame or dseq. The maximum value for a DV25 NTSC frame is 90 (9 audio-DIF-blocks * (10 DIF-sequences / NTSC-frame)) and the maximum value for a DV25 is 108 (9 audio-DIF-blocks * (12 DIF-sequences / PAL-frame)).
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="n_even" type="xsd:integer">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          A count of this particular type of audio error within the even-numbered DIF sequences of the frame. @n minus @n_even would provide the count of this particular type of audio error within the odd-numbered DIF sequences of the frame. A discrepancy between the counts within even and odd DIF sequences can indicate that the associated error is from the playback device of the source tape rather than damage to the source tape. The range is 0-45 for NTSC DV25 and 0-54 for PAL DV25.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
 </xsd:schema>

--- a/tools/dvrescue.xsd
+++ b/tools/dvrescue.xsd
@@ -50,6 +50,7 @@
     <xsd:attribute name="size" type="xsd:string"/>
     <xsd:attribute name="video_rate" type="xsd:string"/>
     <xsd:attribute name="chroma_subsampling" type="xsd:string"/>
+    <xsd:attribute name="scanType" type="xsd:string"/>
     <xsd:attribute name="aspect_ratio" type="xsd:string"/>
     <xsd:attribute name="audio_rate" type="xsd:integer"/>
     <xsd:attribute name="channels" type="xsd:integer"/>

--- a/tools/dvrescue.xsd
+++ b/tools/dvrescue.xsd
@@ -48,7 +48,7 @@
     <xsd:attribute name="video_rate" type="xsd:string"/>
     <xsd:attribute name="chroma_subsampling" type="xsd:string"/>
     <xsd:attribute name="aspect_ratio" type="xsd:string"/>
-    <xsd:attribute name="sample_rate" type="xsd:integer"/>
+    <xsd:attribute name="audio_rate" type="xsd:integer"/>
     <xsd:attribute name="channels" type="xsd:integer"/>
   </xsd:complexType>
 

--- a/tools/dvrescue.xsd
+++ b/tools/dvrescue.xsd
@@ -44,6 +44,9 @@
     <xsd:sequence>
       <xsd:element name="frame" type="frameType" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:integer"/>
+    <xsd:attribute name="pts" type="xsd:string"/>
+    <xsd:attribute name="end_pts" type="xsd:string"/>
     <xsd:attribute name="size" type="xsd:string"/>
     <xsd:attribute name="video_rate" type="xsd:string"/>
     <xsd:attribute name="chroma_subsampling" type="xsd:string"/>

--- a/tools/dvrescue.xsd
+++ b/tools/dvrescue.xsd
@@ -126,7 +126,7 @@
     <xsd:attribute name="n" type="xsd:integer">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
-          A count of this particular type of STA value within the frame. Since STA values only apply to video DIF blocks, the maximum value for a DV25 NTSC frame is 1350 (135 video-DIF-blocks * (10 DIF-sequences / NTSC-frame)) and the maximum value for a DV25 is 1620 (135 video-DIF-blocks * (12 DIF-sequences / PAL-frame)).
+          A count of this particular type of STA value within the frame or dseq. Since STA values only apply to video DIF blocks, the maximum value for a DV25 NTSC frame is 1350 (135 video-DIF-blocks * (10 DIF-sequences / NTSC-frame)) and the maximum value for a DV25 is 1620 (135 video-DIF-blocks * (12 DIF-sequences / PAL-frame)).
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>


### PR DESCRIPTION
The xsd in the add-some-tools branch at https://github.com/mipops/dvrescue/blob/add-some-scripts/tools/dvrescue.xsd covers the current (today) output of dvrescue. This PR includes proposes and considerations for subsequent refinement of the xml output of dvrescue. This includes:
- adding more attributes to frames
- presuming that if frame elements are reported with frames than the first and last will be include (or is the frame sequence duration as a frames attribute feasible?)
- adding a structure for audio errors
- starting to play with default attributes (like mkv elements with defaults) to anticipate reducing the data rate of the xml and aiding in reverse compatibility)
- adding @n_even as a compliement to @n which can be used to infer the cause of the error (tape vs deck)
