### PR TITLE
Fix an int overflow in seconds_to_timestamp()

### DIFF
--- a/Source/Common/Output.cpp
+++ b/Source/Common/Output.cpp
@@ -60,7 +60,7 @@ void seconds_to_timestamp(string& Data, double Seconds_Float, int CountAfterComm
         Powered = int(Powered_Float);
         Seconds_Float *= Powered_Float;
     }
-    auto Seconds_Multiplied = int(trunc?floor(Seconds_Float):lround(Seconds_Float));
+    auto Seconds_Multiplied = (unsigned long long)(trunc?floor(Seconds_Float):lround(Seconds_Float));
     auto Seconds = Seconds_Multiplied;
     int AfterComma;
     if (CountAfterComma)
@@ -68,14 +68,22 @@ void seconds_to_timestamp(string& Data, double Seconds_Float, int CountAfterComm
         Seconds /= Powered;
         AfterComma = Seconds_Multiplied % Powered;
     }
+    auto HundredsOfHours = Seconds / 360000;
+    if (HundredsOfHours)
+    {
+        auto HundredsOfHoursString = to_string(HundredsOfHours);
+        Data.append(HundredsOfHoursString);
+        Seconds %= 360000;
+    }
+    auto S = int(Seconds); // It is guaranted to be less than 360000 so fits in an int
     Data.append("00:00:00");
     auto Value = &Data.back() - 7;
-    Value[0] += Seconds / 36000; Seconds %= 36000;
-    Value[1] += Seconds / 3600; Seconds %= 3600;
-    Value[3] += Seconds / 600; Seconds %= 600;
-    Value[4] += Seconds / 60; Seconds %= 60;
-    Value[6] += Seconds / 10; Seconds %= 10;
-    Value[7] += Seconds;
+    Value[0] += S / 36000; S %= 36000;
+    Value[1] += S / 3600; S %= 3600;
+    Value[3] += S / 600; S %= 600;
+    Value[4] += S / 60; S %= 60;
+    Value[6] += S / 10; S %= 10;
+    Value[7] += S;
     if (CountAfterComma)
     {
         auto AfterCommaString = to_string(AfterComma);

--- a/Source/Common/ProcessFile.cpp
+++ b/Source/Common/ProcessFile.cpp
@@ -124,20 +124,23 @@ void file::AddFrame(const MediaInfo_Event_DvDif_Analysis_Frame_1* FrameData)
     if (FrameData->Errors)
     {
         size_t SizeToCopy = std::strlen(FrameData->Errors) + 1;
-        ToPush->Errors = new char[SizeToCopy];
-        std::memcpy(ToPush->Errors, FrameData->Errors, SizeToCopy);
+        auto Errors = new char[SizeToCopy];
+        std::memcpy(Errors, FrameData->Errors, SizeToCopy);
+        ToPush->Errors = Errors;
     }
     if (FrameData->Video_STA_Errors)
     {
         size_t SizeToCopy = FrameData->Video_STA_Errors_Count * sizeof(size_t);
-        ToPush->Video_STA_Errors = new size_t[SizeToCopy];
-        std::memcpy(ToPush->Video_STA_Errors, FrameData->Video_STA_Errors, SizeToCopy);
+        auto Video_STA_Errors = new size_t[SizeToCopy];
+        std::memcpy(Video_STA_Errors, FrameData->Video_STA_Errors, SizeToCopy);
+        ToPush->Video_STA_Errors = Video_STA_Errors;
     }
     if (FrameData->Audio_Data_Errors)
     {
         size_t SizeToCopy = FrameData->Audio_Data_Errors_Count * sizeof(size_t);
-        ToPush->Audio_Data_Errors = new size_t[SizeToCopy];
-        std::memcpy(ToPush->Audio_Data_Errors, FrameData->Audio_Data_Errors, SizeToCopy);
+        auto Audio_Data_Errors = new size_t[SizeToCopy];
+        std::memcpy(Audio_Data_Errors, FrameData->Audio_Data_Errors, SizeToCopy);
+        ToPush->Audio_Data_Errors = Audio_Data_Errors;
     }
     PerFrame.push_back(ToPush);
 }


### PR DESCRIPTION
After https://github.com/mipops/dvrescue/pull/59, `int` max value is easily hit then there is a an `int` overflow.
Fix crash when relatively big files in input.
At the same time handle timestamps >= 100 hours (I am sure someone will try that one day :) ).