### PR TITLE
Information about caption presence in XML output

### DIFF
--- a/Source/Common/Output_Xml.cpp
+++ b/Source/Common/Output_Xml.cpp
@@ -198,6 +198,10 @@ return_value Output_Xml(ostream& Out, std::vector<file*>& PerFile, ostream* Err)
                     Text += to_string(Change->AudioChannels);
                     Text += '\"';
                 }
+                if (Change->Captions_Flags & 0x1)
+                {
+                    Text += " captions=\"y\"";
+                }
                 Text += ">\n";
             }
 
@@ -285,6 +289,12 @@ return_value Output_Xml(ostream& Out, std::vector<file*>& PerFile, ostream* Err)
                 if (Arb.NonConsecutive())
                 {
                     Text += " arb_nc=\"1\"";
+                }
+
+                // Captions
+                if (Frame->Captions_Errors & 1)
+                {
+                    Text += " caption-parity=\"mismatch\"";
                 }
 
                 // Errors

--- a/Source/Common/ProcessFile.cpp
+++ b/Source/Common/ProcessFile.cpp
@@ -104,7 +104,8 @@ void file::AddChange(const MediaInfo_Event_DvDif_Change_0* FrameData)
             && Current->AudioRate_N == FrameData->AudioRate_N
             && Current->AudioRate_D == FrameData->AudioRate_D
             && Current->AudioChannels == FrameData->AudioChannels
-            && Current->AudioBitDepth == FrameData->AudioBitDepth)
+            && Current->AudioBitDepth == FrameData->AudioBitDepth
+            && Current->Captions_Flags == FrameData->Captions_Flags)
         {
             return;
         }


### PR DESCRIPTION
Resolves #66.
Needs https://github.com/MediaArea/MediaInfoLib/pull/1261.

~~~
<frames count="1" pts="00:00:00.000000" end_pts="00:00:00.033367" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3" audio_rate="48000" channels="2" captions="y">
    <frame n="0" pts="00:00:00.000000" tc="00:00:47;05" arb="F" caption-parity="mismatch">
~~~