### PR TITLE
Fix recdate issues when days >=16

### DIFF
--- a/Source/Common/Output.cpp
+++ b/Source/Common/Output.cpp
@@ -37,7 +37,7 @@ void timecode_to_string(string& Data, int Seconds, bool DropFrame, int Frames)
     Value[4] += Seconds / 60; Seconds %= 60;
     Value[6] += Seconds / 10; Seconds %= 10;
     Value[7] += Seconds;
-    if (Frames < 100)
+    if (Frames < 0x3F) // 6-bit, sometimes set to 0x3F when unknown
     {
         if (DropFrame)
             Value[8] = ';';

--- a/Source/Common/Output.h
+++ b/Source/Common/Output.h
@@ -65,8 +65,8 @@ public:
     inline bool Start() { return _Value1 & (1 << 29); }                             // 1 29
     inline bool NonConsecutive() { return _Value1 & (1 << 30); }                    // 1 30
     inline bool Repeat() { return _Value1 & (1 << 31); }                            // 1 31
-    inline int Frames() { return _Value2 & 0x7F; }                                  // 2  0- 7
-    inline int Days() { return (_Value2 >> 8) & 0x1F; }                             // 2  8-12
+    inline int Frames() { return _Value2 & 0x3F; }                                  // 2  0- 5
+    inline int Days() { return (_Value2 >> 6) & 0x1F; }                             // 2  6-10
     inline int Months() { return (_Value2 >> 12) & 0x0F; }                          // 2 12-15
 
 private:


### PR DESCRIPTION
There was an issue in the API between MediaInfoLib and DVRescue, now using the fixed MediaInfoLib API. Not compatible with MediaInfoLib builds before https://github.com/MediaArea/MediaInfoLib/pull/1322.