### PR TITLE
fix typo in attribute name

### DIFF
--- a/tools/dvrescue.xsd
+++ b/tools/dvrescue.xsd
@@ -357,7 +357,7 @@
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
-    <xsd:attribute name="no_sourceorcontrol_audio" type="xsd:boolean">
+    <xsd:attribute name="no_sourceorcontrol_aud" type="xsd:boolean">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Boolean that indicates if no audio source and no video source control pack is present in video but at least 1 pack is present in audio.


### PR DESCRIPTION
fixes the xsd to match https://github.com/mipops/dvrescue/blob/b9d3f24099245952e53d7691eff57484b5d8da95/Source/Common/Output.h#L87