### PR TITLE
Fix dvpackager FFmpeg detection when Homebrew is not installed

### DIFF
--- a/tools/dvpackager
+++ b/tools/dvpackager
@@ -228,7 +228,7 @@ elif [[ -d "/home/linuxbrew/.linuxbrew/opt/ffmpegdecklink" ]] ; then
 else
     BREW_PREFIX="$(brew --prefix ffmpegdecklink 2>/dev/null)"
 fi
-if [[ -d "${BREW_PREFIX}/bin" ]] ; then
+if [[ -n "${BREW_PREFIX}" && -d "${BREW_PREFIX}/bin" ]] ; then
     FFMPEG_PATH="${BREW_PREFIX}/bin/ffmpeg-dl"
 else
     FFMPEG_PATH="$(which ffmpeg)"


### PR DESCRIPTION
When Homebrew is not installed, dvpackager ends up defining ```${BREW_PREFIX}``` as an empty string. This causes ```${BREW_PREFIX}/bin``` to become ```/bin```, making dvpackager look for FFmpeg at ```/bin/ffmpeg-dl```. This means that dvpackager never gets to look for FFmpeg using ```$(which ffmpeg)```.

This PR adds a check to ensure ```${BREW_PREFIX}``` is not empty before looking for FFmpeg at ```${BREW_PREFIX}/bin/ffmpeg-dl```, allowing dvpackager to use ```$(which ffmpeg)``` if Homebrew is not installed.