### PR TITLE
Library options available from DVRescue command line

### DIFF
--- a/Source/CLI/CLI_Help.cpp
+++ b/Source/CLI/CLI_Help.cpp
@@ -78,6 +78,9 @@ return_value Help(ostream& Out, const char* Name, bool Full)
         "        7: information per frame if there is a problem + summary.\n"
         "        9: information per frame + summary.\n"
         "\n"
+        "    --timeout value\n"
+        "        Time out limit for the pipe input (\"-\" file name) set to value (in seconds)\n"
+        "\n"
         "If no output file name is provided, XML output is displayed on console output."
         "\n"
         << endl;

--- a/Source/CLI/CommandLine_Parser.cpp
+++ b/Source/CLI/CommandLine_Parser.cpp
@@ -265,6 +265,33 @@ return_value Parse(Core &C, int argc, const char* argv_ansi[], const MediaInfoNa
             else
                 C.XmlFile = File;
         }
+        else if (!strncmp(argv_ansi[i], "--", 2))
+        {
+            //Library options, we may accept either --option value or --option=value
+            String Option(argv[i] + 2);
+            auto EqualPos = Option.find('=');
+            String Value;
+            if (EqualPos != string::npos)
+            {
+                Value.assign(Option, EqualPos + 1);
+                Option.resize(EqualPos);
+                EqualPos = 0;
+            }
+            else
+            {
+                if (++i >= argc)
+                {
+                    if (C.Err)
+                        *C.Err << "Error: missing value after " << argv_ansi[i - 1] << ".\n";
+                    return ReturnValue_ERROR;
+                }
+                Value.assign(argv[i]);
+                EqualPos = 1;
+            }
+            String Result = MediaInfoLib::MediaInfo::Option_Static(Option, Value);
+            if (C.Err && !Result.empty())
+                *C.Err << "Warning: issue with " << argv_ansi[i - EqualPos];
+        }
         else
         {
             if (C.WebvttFile || C.XmlFile || !Merge_OutputFileName.empty())

--- a/Source/Common/ProcessFile.cpp
+++ b/Source/Common/ProcessFile.cpp
@@ -205,7 +205,7 @@ void file::AddFrame(const MediaInfo_Event_Global_Demux_4* FrameData)
     // DV frame
     if (!FrameData->StreamIDs_Size || FrameData->StreamIDs[FrameData->StreamIDs_Size-1]==-1)
     {
-        if (Merge_InputFileNames.empty() || Merge_InputFileNames[0] == "-") // Only for stdin
+        if (!Merge_OutputFileName.empty() && (Merge_InputFileNames.empty() || Merge_InputFileNames[0] == "-")) // Only for stdin
             Merge.AddFrame(Merge_FilePos, FrameData);
         return;
     }


### PR DESCRIPTION
Include time out limit for the pipe input after https://github.com/MediaArea/MediaInfoLib/pull/1379 is merged.