### PR TITLE
PTS

### DIFF
--- a/Source/Common/Output_Webvtt.cpp
+++ b/Source/Common/Output_Webvtt.cpp
@@ -110,7 +110,7 @@ return_value Output_Webvtt(ostream& Out, std::vector<file*>& PerFile, ostream* E
                 // Empty line
                 Text += '\n';
 
-                auto TimeStamp2 = (FrameNumber + 1) / File->FrameRate;
+                auto TimeStamp2 = Frame->PTS / 1000000000.0;
                 seconds_to_timestamp(TimeStamp2_String, TimeStamp2, 3, true);
 
                 Text += TimeStamp_String;

--- a/Source/Common/Output_Xml.cpp
+++ b/Source/Common/Output_Xml.cpp
@@ -207,13 +207,13 @@ return_value Output_Xml(ostream& Out, std::vector<file*>& PerFile, bitset<Option
                     Text += '\"';
                 }
                 {
-                    auto TimeStamp_Begin = FrameNumber / File->FrameRate;
+                    auto TimeStamp_Begin = Frame->PTS / 1000000000.0; // FrameNumber / File->FrameRate;
                     Text += " pts=\"";
                     seconds_to_timestamp(Text, TimeStamp_Begin, 6);
                     Text += '\"';
                 }
                 {
-                    auto TimeStamp_End = (PerChange_Next != File->PerChange.end() ? (*PerChange_Next)->FrameNumber : (FrameNumber_Max + 1)) / File->FrameRate;
+                    auto TimeStamp_End = (PerChange_Next != File->PerChange.end() ? (*PerChange_Next)->PTS : (File->PerFrame.back()->PTS + File->PerFrame.back()->DUR)) / 1000000000.0; //(PerChange_Next != File->PerChange.end() ? (*PerChange_Next)->FrameNumber : (FrameNumber_Max + 1)) / File->FrameRate;
                     Text += " end_pts=\"";
                     seconds_to_timestamp(Text, TimeStamp_End, 6);
                     Text += '\"';
@@ -296,7 +296,7 @@ return_value Output_Xml(ostream& Out, std::vector<file*>& PerFile, bitset<Option
 
             if (ShowFrame)
             {
-                auto TimeStamp = FrameNumber / File->FrameRate;
+                auto TimeStamp = Frame->PTS / 1000000000.0;
 
                 Text += "\t\t\t<frame";
                 {

--- a/Source/Common/ProcessFile.cpp
+++ b/Source/Common/ProcessFile.cpp
@@ -238,6 +238,8 @@ void file::AddFrame(const MediaInfo_Event_Global_Demux_4* FrameData)
         if (Dseq >= PerFrame_Captions_PerSeq_PerField.size())
             PerFrame_Captions_PerSeq_PerField.resize(Dseq + 1);
         auto& PerSeq = PerFrame_Captions_PerSeq_PerField[Dseq];
+        PerSeq.PTS = FrameData->PTS / 1000000000.0;
+        PerSeq.DUR = FrameData->DUR / 1000000000.0;
         auto& FieldData = PerSeq.FieldData[i];
         if (FieldData.empty() || FieldData.back().StartFrameNumber + FieldData.back().Captions.size() != FrameNumber)
             FieldData.emplace_back(FrameNumber);

--- a/Source/Common/ProcessFile.h
+++ b/Source/Common/ProcessFile.h
@@ -72,6 +72,8 @@ public:
     };
     struct captions_data
     {
+        double PTS;
+        double DUR;
         vector<captions_fielddata> FieldData[2];
     };
     vector<captions_data> PerFrame_Captions_PerSeq_PerField;


### PR DESCRIPTION
Fix https://github.com/mipops/dvrescue/issues/284.

Needs https://github.com/MediaArea/MediaInfoLib/pull/1392.

Use PTS from the DV library instead of frame number divided by frame rate, except for SCC output because it relies too much on time codes with a frame number after seconds (`00:00:00;00` format) and not adapted to change of frame rate.