### PR TITLE
Use abst as a hint for timecode sync, proof of concept

### DIFF
--- a/Source/CLI/CommandLine_Parser.cpp
+++ b/Source/CLI/CommandLine_Parser.cpp
@@ -194,6 +194,30 @@ return_value Parse(Core &C, int argc, const char* argv_ansi[], const MediaInfoNa
             else
                 MergeInfo_OutputFileName = argv_ansi[i];
         }
+        else if (!strcmp(argv_ansi[i], "--use-abst"))
+        {
+            if (++i >= argc)
+            {
+                if (C.Err)
+                    *C.Err << "Error: missing value (y or n) after " << argv_ansi[i-1] << ".\n";
+                ReturnValue = ReturnValue_ERROR;
+                continue;
+            }
+            switch (argv_ansi[i][0])
+            {
+                case 'n':
+                    UseAbst = 0;
+                    break;
+                case 'y':
+                    UseAbst = 1;
+                    break;
+                default:
+                    if (C.Err)
+                        *C.Err << "Error: invalid value " << argv_ansi[i] << " (must be y or n).\n";
+                    ReturnValue = ReturnValue_ERROR;
+                    continue;
+            }
+        }
         else if (!strcmp(argv_ansi[i], "--verbosity") || !strcmp(argv_ansi[i], "-v"))
         {
             if (++i >= argc)

--- a/Source/Common/Merge.cpp
+++ b/Source/Common/Merge.cpp
@@ -775,7 +775,7 @@ bool dv_merge_private::Process()
     {
         if (Verbosity <= 7)
             Count_Last_OK_Frames++;
-        else
+        else if (Prefered_Abst != -2)
             cout << '\n';
     }
 
@@ -904,6 +904,8 @@ bool dv_merge_private::Process()
 
     if (Verbosity > 5 && Prefered_Abst == -2)
     {
+        if (IsOK)
+            cout << setw(Inputs.size() + 1) << ' ';
         cout << ", abst";
         for (size_t i = 0; i < Input_Count; i++)
         {
@@ -912,7 +914,7 @@ bool dv_merge_private::Process()
             auto& Frame = Frames[Frame_Pos];
             if (Frame.Abst == numeric_limits<int>::max())
             {
-                cout << " missin"; // missing but only 6 chars for abst
+                cout << Frame.Status[Status_FrameMissing] ? "       " : " missin"; // missing abst but only 6 chars for abst
             }
             else
             {
@@ -951,8 +953,8 @@ bool dv_merge_private::Process()
 
     if (Prefered_Frame != -1) // Write only if there is some content from this specific frame
         fwrite(Output.Buffer, BlockStatus_Count * 80, 1, Output.F);
-    if (Verbosity > 5 && !IsOK)
-        cout << endl;
+    if (Verbosity > 5 && (!IsOK || Prefered_Abst == -2))
+        cout << '\n';
 
     Frame_Pos++;
     return false;

--- a/Source/Common/Merge.h
+++ b/Source/Common/Merge.h
@@ -19,6 +19,7 @@ extern vector<string> Merge_InputFileNames;
 extern string Merge_OutputFileName;
 extern string MergeInfo_OutputFileName;
 extern uint8_t Verbosity;
+extern uint8_t UseAbst;
 struct MediaInfo_Event_DvDif_Analysis_Frame_1;
 struct MediaInfo_Event_Global_Demux_4;
 


### PR DESCRIPTION
(Note: early stage, use it only as a proof of concept)

Option ` --use-abst y` to be used during merge of 2 files.
Without the new option, time code sync is wrong (begin of second file is synced with the first frames of first file having the same time code), abst mismatch seen.
With the option, time code sync is good (begin of second file is synced with the the second part of first frame).

```
dvrescue BCD00217_take2_54000000_Frame0-97.dv BCD00217_take1_54000000_Frame94-97.dv -m a.dv --verbosity 9 --use-abst n
     #|Abst  |HH:MM:SS:FF|U|St|Comments
     0   3480 00:00:00;00 X PM, 1331    0 block picks &  109 remaining block errors
     1 ?????? 00:00:00;01 0   , abst   3495   3071
     2 ?????? 00:00:00;02 0   , abst   3510   3086
     3 ?????? 00:00:00;03 0  P, abst   3525   3101
     4 ?????? 00:00:00;04 0  P, abst   3540   3119
     5   3555 00:00:00;05 0  M
...
    92   4860 00:00:03;02 0  M
    93   3064 00:00:03;03 X PM,  861    0 block picks &  579 remaining block errors
    94   3071 00:00:00:01 0  M
    95   3086 00:00:00:02 0  M
    96   3101 00:00:00:03 X PM, 1010    0 block picks &  430 remaining block errors
    97   3119 00:00:00:04 X PM,  481    0 block picks &  959 remaining block errors

dvrescue BCD00217_take2_54000000_Frame0-97.dv BCD00217_take1_54000000_Frame94-97.dv -m a.dv --verbosity 9 --use-abst y
     #|Abst  |HH:MM:SS:FF|U|St|Comments
     0   3480 00:00:00;00 X PM, 1331    0 block picks &  109 remaining block errors
     1   3495 00:00:00;01 0  M
     2   3510 00:00:00;02 0  M
     3   3525 00:00:00;03 0  M
     4   3540 00:00:00;04 0  M
     5   3555 00:00:00;05 0  M
...
    92   4860 00:00:03;02 0  M
    93   3064 00:00:03;03 X PM,  861    0 block picks &  579 remaining block errors
    94   3071 00:00:00:01 0
    95   3086 00:00:00:02 0
    96   3101 00:00:00:03 X PP, 1010   16 block picks &  414 remaining block errors
    97   3119 00:00:00:04 X PP,   69  677 block picks &  694 remaining block errors
```
