### PR TITLE
Add DV speed in XML output, split frames element by DV speed

### DIFF
--- a/Source/Common/Output.h
+++ b/Source/Common/Output.h
@@ -174,6 +174,11 @@ public:
     dseq PerDseq;
 };
 
+int GetDvSpeed(const MediaInfo_Event_DvDif_Analysis_Frame_1& Frame);
+int GetDvSpeedIfNotPlayback(const MediaInfo_Event_DvDif_Analysis_Frame_1& Frame);
+bool DvSpeedHasChanged(const MediaInfo_Event_DvDif_Analysis_Frame_1* PreviousFrame, const MediaInfo_Event_DvDif_Analysis_Frame_1* CurrentFrame);
+bool DvSpeedHasChanged(std::vector<MediaInfo_Event_DvDif_Analysis_Frame_1*>& PerFrame);
+
 //***************************************************************************
 // Writing
 //***************************************************************************

--- a/Source/Common/Output_Xml.cpp
+++ b/Source/Common/Output_Xml.cpp
@@ -226,6 +226,7 @@ return_value Output_Xml(ostream& Out, std::vector<file*>& PerFile, bitset<Option
                             const auto Size_After = Change->EventSize - Offset_After;
                             if ((Size_Before && memcmp((const char*)&Change->Captions_Flags - Size_Before, (const char*)&(*PerChange_Next)->Captions_Flags - Size_Before, Size_Before))
                                 || (Size_After && memcmp((const char*)&Change->Captions_Flags + sizeof(MediaInfo_Event_DvDif_Change_0::Captions_Flags), (const char*)&(*PerChange_Next)->Captions_Flags + sizeof(MediaInfo_Event_DvDif_Change_0::Captions_Flags), Size_After))
+                                || ((*PerChange_Next)->FrameNumber && DvSpeedHasChanged(File->PerFrame[(*PerChange_Next)->FrameNumber - 1], File->PerFrame[(*PerChange_Next)->FrameNumber]) != INT_MIN)
                                 || ((Change->Captions_Flags&(~1)) != ((*PerChange_Next)->Captions_Flags&(~1)))) // Any bit but bit 0
                                 break;
                             HasChanges = true;
@@ -325,6 +326,13 @@ return_value Output_Xml(ostream& Out, std::vector<file*>& PerFile, bitset<Option
                 if (no_sourceorcontrol_aud_Everywhere)
                 {
                     Text += " no_sourceorcontrol_aud=\"1\"";
+                }
+                auto DvSpeed = GetDvSpeedIfNotPlayback(*Frame);
+                if (DvSpeed != INT_MIN)
+                {
+                    Text += " speed=\"";
+                    Text += to_string(DvSpeed);
+                    Text += '\"';
                 }
                 Text += ">\n";
             }

--- a/Source/Common/ProcessFile.cpp
+++ b/Source/Common/ProcessFile.cpp
@@ -441,7 +441,7 @@ void file::AddFrameAnalysis(const MediaInfo_Event_DvDif_Analysis_Frame_1* FrameD
         if (!PerChange.empty() && ToPush->FrameNumber == PerChange.back()->FrameNumber)
             no_sourceorcontrol_aud_set_in_first_frame = true;
     }
-    if (no_sourceorcontrol_aud_set_in_first_frame && (Coherency.no_pack_aud() || !Coherency.no_sourceorcontrol_aud()))
+    if (no_sourceorcontrol_aud_set_in_first_frame && (Coherency.no_pack_aud() || !Coherency.no_sourceorcontrol_aud()) || DvSpeedHasChanged(PerFrame))
     {
         if (PerChange.back()->FrameNumber != FrameNumber - 1)
         {

--- a/tools/dvrescue.xsd
+++ b/tools/dvrescue.xsd
@@ -134,6 +134,13 @@
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
+    <xsd:attribute name="speed" type="xsd:integer">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Integer that indicates the speed stored in the DV frames. Range from -127 to 127. Not provided if value is 31 or 32 (considered as normal playback).
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
   </xsd:complexType>
 
   <xsd:simpleType name="sizeType">


### PR DESCRIPTION
with e.g. fastForwardPauseRewind.dv.
 Before:
```
<frames count="698" pts="00:00:00.000000" end_pts="00:00:23.289933" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3" captions="p">
<frames count="104" pts="00:00:23.289933" end_pts="00:00:26.760066" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3" audio_rate="32000" channels="4">
```

After:
```
<frames count="107" pts="00:00:00.000000" end_pts="00:00:03.570233" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3">
<frames count="2" pts="00:00:03.570233" end_pts="00:00:03.636966" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3" speed="49">
<frames count="151" pts="00:00:03.636966" end_pts="00:00:08.675333" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3" speed="83">
<frames count="6" pts="00:00:08.675333" end_pts="00:00:08.875533" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3" speed="49">
<frames count="25" pts="00:00:08.875533" end_pts="00:00:09.709700" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3">
<frames count="140" pts="00:00:09.709700" end_pts="00:00:14.381033" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3" speed="0">
<frames count="137" pts="00:00:14.381033" end_pts="00:00:18.952266" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3">
<frames count="20" pts="00:00:18.952266" end_pts="00:00:19.619600" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3" speed="0">
<frames count="28" pts="00:00:19.619600" end_pts="00:00:20.553866" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3" speed="-31">
<frames count="2" pts="00:00:20.553866" end_pts="00:00:20.620600" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3" speed="-49">
<frames count="79" pts="00:00:20.620600" end_pts="00:00:23.256566" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3" speed="-83">
<frames count="1" pts="00:00:23.256566" end_pts="00:00:23.289933" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3" no_sourceorcontrol_aud="1">
<frames count="104" pts="00:00:23.289933" end_pts="00:00:26.760066" size="720x480" video_rate="30000/1001" chroma_subsampling="4:1:1" aspect_ratio="4/3" audio_rate="32000" channels="4" speed="-83">
```

Note: frame at 00:00:23.256566 has not DV speed info, it is considered like normal playback, so the "jumps" from -83 to no value to -83. Maybe not the best approach, should unknown DV speed not triggering a `frames` element split?

Requires https://github.com/MediaArea/MediaInfoLib/pull/1571 for right behavior in case of no DV speed metadata in DV frame.

Resolves https://github.com/mipops/dvrescue/issues/328.