### PR TITLE
Check if file exists before overwriting

### DIFF
--- a/Source/Common/Core.cpp
+++ b/Source/Common/Core.cpp
@@ -60,7 +60,7 @@ return_value Core::Process()
     }
     if (Device_Command)
         return ReturnValue_OK;
-    if (!Merge_OutputFileName.empty())
+    if (Merge_Out)
     {
         PerFile[0]->Merge_Finish();
         if (!XmlFile)

--- a/Source/Common/Merge.h
+++ b/Source/Common/Merge.h
@@ -17,8 +17,8 @@ using namespace std;
 //***************************************************************************
 
 extern vector<string> Merge_InputFileNames;
-extern string Merge_OutputFileName;
-extern string MergeInfo_OutputFileName;
+extern FILE* Merge_Out;
+extern ostream* MergeInfo_Out;
 extern uint8_t MergeInfo_Format;
 extern uint8_t Verbosity;
 extern uint8_t UseAbst;

--- a/Source/Common/ProcessFile.cpp
+++ b/Source/Common/ProcessFile.cpp
@@ -462,7 +462,7 @@ void file::AddFrameAnalysis(const MediaInfo_Event_DvDif_Analysis_Frame_1* FrameD
         no_sourceorcontrol_aud_set_in_first_frame = false;
     }
 
-    if (!Merge_OutputFileName.empty())
+    if (Merge_Out)
     {
         auto Speed = abs(Speed_Before) > abs(Speed_After) ? Speed_Before : Speed_After;
         Speed_Before = Speed_After;
@@ -548,7 +548,7 @@ void file::AddFrameData(const MediaInfo_Event_Global_Demux_4* FrameData)
     // DV frame
     if (!FrameData->StreamIDs_Size || FrameData->StreamIDs[FrameData->StreamIDs_Size-1]==-1)
     {
-        if (!Merge_OutputFileName.empty() && (Merge_InputFileNames.empty() || Merge_InputFileNames[0] == "-" || Merge_InputFileNames[0].find("device://") == 0)) // Only for stdin
+        if (Merge_Out && (Merge_InputFileNames.empty() || Merge_InputFileNames[0] == "-" || Merge_InputFileNames[0].find("device://") == 0)) // Only for stdin
             Merge.AddFrameData(Merge_FilePos, FrameData->Content, FrameData->Content_Size);
 
         Device_LastPacketTime = chrono::steady_clock::now();

--- a/Source/GUI/dvrescue/dvrescue/DvRescueCLI.qml
+++ b/Source/GUI/dvrescue/dvrescue/DvRescueCLI.qml
@@ -165,7 +165,7 @@ Item {
                 launcher.destroy();
             });
 
-            var arguments = ['device://' + index, '-capture', '-cmd', captureCmd, '-m', '-', '--verbosity', '9', '--csv']
+            var arguments = ['-y', 'device://' + index, '-capture', '-cmd', captureCmd, '-m', '-', '--verbosity', '9', '--csv']
 
             launcher.execute(cmd, arguments);
             if(callback)
@@ -223,7 +223,7 @@ Item {
             var xml = file + ".dvrescue.xml"
             var scc = file + ".scc"
 
-            var arguments = ['device://' + index, '-x', xml, '-c', scc, '--cc-format', 'scc', '-m', '-', '--verbosity', '9', '--csv']
+            var arguments = ['-y', 'device://' + index, '-x', xml, '-c', scc, '--cc-format', 'scc', '-m', '-', '--verbosity', '9', '--csv']
 
             launcher.execute(cmd, arguments);
             if(callback)
@@ -266,7 +266,7 @@ Item {
                 launcher.destroy();
             });
 
-            var makeReportTemplate = "file.dv -x file.dv.dvrescue.xml -s file.dv.dvrescue.vtt -c file.dv.dvrescue.scc";
+            var makeReportTemplate = "-y file.dv -x file.dv.dvrescue.xml -s file.dv.dvrescue.vtt -c file.dv.dvrescue.scc";
             var arguments = makeReportTemplate.split(" ");
             for(var i = 0; i < arguments.length; ++i) {
                 arguments[i] = arguments[i].replace("file.dv", file);


### PR DESCRIPTION
CLI with interactive mode if file exists, and `-n`/`-y` options for overriding it.
GUI (no risk to swap file names with it, but still a risk of unexpected overwrite) with `-y`, @g-maxime can we check if files exists and ask if writing is fine directly in the GUI?

For XML, WebVTT, log, merge outputs.

Fix https://github.com/mipops/dvrescue/issues/559.