### PR TITLE
dvpackager: declare STARTMESSAGE as array

### DIFF
--- a/tools/dvpackager
+++ b/tools/dvpackager
@@ -594,7 +594,7 @@ _report(){
     local MAGENTA="$(tput setaf 5)" # Magenta - For Verbose Statements
     local NC="$(tput sgr0)"        # No Color
     local COLOR=""
-    local STARTMESSAGE=""
+    local STARTMESSAGE=()
     local ECHOOPT=""
     local VERBOSE_CHECK=false
     OPTIND=1


### PR DESCRIPTION
Avoid it to be evaluated to \0177 (on some bash versions?)

Signed-off-by: Maxime Gervais <gervais.maxime@gmail.com>