### PR TITLE
Do not store garbage data if partial frame received

### DIFF
--- a/Source/Common/Merge.cpp
+++ b/Source/Common/Merge.cpp
@@ -856,8 +856,11 @@ bool dv_merge_private::Process(float Speed)
                 auto BytesRead = fread(Frame.Buffer.Data, 1, Frame_Size, Input->F);
                 Frame.Buffer.Size = BytesRead;
                 Input->F_Pos += BytesRead;
-                if (BytesRead != Frame.BlockStatus_Count * 80)
+                if (Frame.Buffer.Size != Frame.BlockStatus_Count * 80)
+                {
                     *Log << "File read issue." << endl;
+                    Frame.BlockStatus_Count = Frame.Buffer.Size / 80;
+                }
                 if (Frame.RepeatCount)
                 {
                     if (fseek(Input->F, (long)(Frame.BlockStatus_Count * 80 * Frame.RepeatCount), SEEK_CUR))
@@ -870,7 +873,10 @@ bool dv_merge_private::Process(float Speed)
                 Frame.Buffer = Input->DV_Data->move();
                 Input->F_Pos += Frame.Buffer.Size;
                 if (Frame.Buffer.Size != Frame.BlockStatus_Count * 80)
+                {
                     *Log << "File read issue." << endl;
+                    Frame.BlockStatus_Count = Frame.Buffer.Size / 80;
+                }
             }
         }
         else


### PR DESCRIPTION
In the case of e.g. pipe and ingest is stopped in the middle of a frame, or if a file size is not a multiple of 120000, output is filled with garbage up to a multiple of 120000.

This patch removes such garbage data in output, and store last frame with only blocks available.