### PR TITLE
Use output file name and size for XML report during capture

### DIFF
--- a/Source/Common/Merge.cpp
+++ b/Source/Common/Merge.cpp
@@ -25,6 +25,7 @@ uint64_t VariableSize(const uint8_t* Buffer, size_t& Buffer_Offset, size_t Buffe
 //---------------------------------------------------------------------------
 vector<string> Merge_InputFileNames;
 FILE* Merge_Out = nullptr;
+uint64_t Merge_Out_Size = -1;
 const char* Merge_OutputFileName = nullptr;
 ostream* MergeInfo_Out = nullptr;
 ofstream Out;
@@ -1767,6 +1768,9 @@ bool dv_merge_private::Stats()
         *Log << '\n';
     }
     *Log << flush;
+
+    if (Output.F_Pos)
+        Merge_Out_Size = Output.F_Pos;
 
     return false;
 }

--- a/Source/Common/Output_Xml.cpp
+++ b/Source/Common/Output_Xml.cpp
@@ -21,6 +21,10 @@ using namespace ZenLib;
 //***************************************************************************
 
 //---------------------------------------------------------------------------
+extern const char* Merge_OutputFileName; 
+extern uint64_t Merge_Out_Size;
+
+//---------------------------------------------------------------------------
 static const char* const Writer_Name = "XML";
 
 //***************************************************************************
@@ -146,6 +150,8 @@ return_value Output_Xml(ostream& Out, std::vector<file*>& PerFile, bitset<Option
             continue; // Show the file only if it exists
         Text += "\t<media";
         auto FileName = File->MI.Get(Stream_General, 0, __T("CompleteName"));
+        if (FileName.empty() && Merge_OutputFileName)
+            FileName = Ztring().From_Local(Merge_OutputFileName);
         if (!FileName.empty())
         {
             Text += " ref=\"";
@@ -169,6 +175,8 @@ return_value Output_Xml(ostream& Out, std::vector<file*>& PerFile, bitset<Option
             Text += '\"';
         }
         auto FileSize = File->MI.Get(Stream_General, 0, __T("FileSize"));
+        if (FileSize.empty() && Merge_Out_Size != -1)
+            FileSize = Ztring::ToZtring(Merge_Out_Size);
         if (!FileSize.empty())
         {
             Text += " size=\"";


### PR DESCRIPTION
So XML during capture is (at least it is the goal) same as XML on the stored file.

Same file name, same size, in both XMLs.