### PR TITLE
Allow to use AVDevice uniqueID instead of device index

### DIFF
--- a/Source/CLI/CommandLine_Parser.cpp
+++ b/Source/CLI/CommandLine_Parser.cpp
@@ -389,7 +389,7 @@ return_value Parse(Core &C, int argc, const char* argv_ansi[], const MediaInfoNa
                 ReturnValue = ReturnValue_ERROR;
                 continue;
             }
-            Device_Pos = atoi(argv_ansi[i]);
+            Device = argv_ansi[i];
             C.Inputs.push_back(String(__T("device://")) + argv[i]);
         }
         else if (!strcmp(argv_ansi[i], "--cmd") || !strcmp(argv_ansi[i], "-cmd"))

--- a/Source/Common/AvfCtl.h
+++ b/Source/Common/AvfCtl.h
@@ -40,8 +40,11 @@
 
 + (NSUInteger) getDeviceCount;
 + (NSString*) getDeviceName:(NSUInteger) index;
++ (NSString*) getDeviceID:(NSUInteger) index;
++ (NSInteger) getDeviceIndex:(NSString*) uniqueID;
 + (BOOL) isTransportControlsSupported:(NSUInteger) index;
 - (id) initWithDeviceIndex:(NSUInteger) index;
+- (id) initWithDeviceID:(NSString*) uniqueID;
 - (void) dealloc;
 - (NSString*) getStatus;
 - (void) createCaptureSession:(id) receiver;

--- a/Source/Common/AvfCtlWrapper.h
+++ b/Source/Common/AvfCtlWrapper.h
@@ -20,11 +20,15 @@ class AVFCtlWrapper : public BaseWrapper {
 public:
     // Constructor/Destructor
     AVFCtlWrapper(std::size_t DeviceIndex);
+    AVFCtlWrapper(std::string DeviceID);
     ~AVFCtlWrapper();
 
     // Functions
     static std::size_t GetDeviceCount();
     static std::string GetDeviceName(std::size_t DeviceIndex);
+    static std::string GetDeviceName(const std::string& DeviceID);
+    static std::string GetDeviceID(std::size_t DeviceIndex);
+    static std::size_t GetDeviceIndex(const std::string& DeviceID);
     std::string GetStatus();
     float GetSpeed();
     playback_mode GetMode();

--- a/Source/Common/AvfCtlWrapper.mm
+++ b/Source/Common/AvfCtlWrapper.mm
@@ -64,6 +64,11 @@ AVFCtlWrapper::AVFCtlWrapper(size_t DeviceIndex)
     Ctl = (void*)[[AVFCtl alloc] initWithDeviceIndex:DeviceIndex];
 }
 
+AVFCtlWrapper::AVFCtlWrapper(string DeviceID)
+{
+    Ctl = (void*)[[AVFCtl alloc] initWithDeviceID:[NSString stringWithUTF8String:DeviceID.c_str()]];
+}
+
 AVFCtlWrapper::~AVFCtlWrapper()
 {
     [(id)Ctl release];
@@ -77,6 +82,29 @@ size_t AVFCtlWrapper::GetDeviceCount()
 string AVFCtlWrapper::GetDeviceName(size_t DeviceIndex)
 {
     return string([[AVFCtl getDeviceName:DeviceIndex] UTF8String]);
+}
+
+string AVFCtlWrapper::GetDeviceName(const std::string& DeviceID)
+{
+    NSInteger DeviceIndex = GetDeviceIndex(DeviceID);
+    if (DeviceIndex < 0)
+        return string();
+
+    return string([[AVFCtl getDeviceName:DeviceIndex] UTF8String]);
+}
+
+string AVFCtlWrapper::GetDeviceID(size_t DeviceIndex)
+{
+    return string([[AVFCtl getDeviceID:DeviceIndex] UTF8String]);
+}
+
+size_t AVFCtlWrapper::GetDeviceIndex(const string& DeviceID)
+{
+    NSInteger index = [AVFCtl getDeviceIndex:[NSString stringWithUTF8String:DeviceID.c_str()]];
+    if (index < 0)
+        return (size_t)-1;
+
+    return (size_t)index;
 }
 
 string AVFCtlWrapper::GetStatus()

--- a/Source/Common/Merge.h
+++ b/Source/Common/Merge.h
@@ -29,7 +29,7 @@ extern bool OutputFrames_Concealed;
 extern int ShowFrames_Missing;
 extern int ShowFrames_Intermediate;
 extern bool InControl;
-extern uint64_t Device_Pos;
+extern string Device;
 extern char Device_Command;
 extern bool Device_ForceCapture;
 extern unsigned int Device_Mode;


### PR DESCRIPTION
Example:
```
 % ./dvrescue -list_devices             
0x80880503631782: GR-D70 (JVC GR-D70)

% ./dvrescue device://0x80880503631782
...
```

Snapshot: https://mediaarea.net/download/snapshots/binary/dvrescue/20221124/dvrescue_CLI_0.21.11.20221124_Mac.dmg

Signed-off-by: Maxime Gervais <gervais.maxime@gmail.com>