### PR TITLE
macOS CLI: Allow loading of external decklink library

### DIFF
--- a/Project/Mac/CLI.entitlements
+++ b/Project/Mac/CLI.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/Project/Mac/mkdmg.sh
+++ b/Project/Mac/mkdmg.sh
@@ -69,7 +69,7 @@ if [ "$KIND" = "CLI" ]; then
     cp "../../tools/dvsampler" "${FILES}-Root/usr/local/bin"
     cp "../../tools/avfctl/avfctl" "${FILES}-Root/usr/local/bin"
     cp "../../Source/CLI/dvrescue.1" "${FILES}-Root/usr/local/share/man/man1"
-    codesign -f --options=runtime -s "Developer ID Application: ${SIGNATURE}" --verbose "${FILES}-Root/usr/local/bin/${APPNAME_lower}"
+    codesign -f --options=runtime -s "Developer ID Application: ${SIGNATURE}" --verbose --entitlements CLI.entitlements "${FILES}-Root/usr/local/bin/${APPNAME_lower}"
     codesign -f --options=runtime -s "Developer ID Application: ${SIGNATURE}" --verbose "${FILES}-Root/usr/local/bin/avfctl"
 
     pkgbuild --root "${FILES}-Root" --identifier "net.MediaArea.${APPNAME_lower}.mac-${KIND_lower}" --sign "Developer ID Installer: ${SIGNATURE}" --version "${VERSION}" "${FILES}/${APPNAME_lower}.pkg"


### PR DESCRIPTION
Fixes #715 

Please test [this snapshot](https://mediaarea.net/download/snapshots/binary/dvrescue/20230716/dvrescue_CLI_0.21.11.20230716_Mac.dmg)