### PR TITLE
Update dvplay color coding

### DIFF
--- a/tools/dvplay
+++ b/tools/dvplay
@@ -578,7 +578,7 @@ while [[ "${@}" != "" ]] ; do
         FIRST_NON_EMPTY_OFFSET="${#FIRST_NON_EMPTY_OFFSET_TMP}"
         COUNT_INPUT_PATH="${#INPUTFILE_PATH[@]}"
         COUNT_INPUT_OFFSET="${#INPUTFILE_OFFSET[@]}"
-        COLOR=(red green blue magenta yellow cyan)
+        COLOR=(orange hotpink blue mediumpurple yellow cyan)
         INPUT_COUNTER=0
         MAP_COUNTER=0
         unset INPUT_SET MAP_SET FILTER_SET


### PR DESCRIPTION
I changed the colors to replace red and green (we use those a lot for symbolizing "good" vs. "bad" or warnings) with orange and pink. I also changed the shade of purple so the contrast was more noticeable in this order to make it more ADA friendly.