### PR TITLE
GUI: fix double-free on capture stop/application exit

### DIFF
--- a/Source/GUI/dvrescue/dvrescue/mediaplayer.cpp
+++ b/Source/GUI/dvrescue/dvrescue/mediaplayer.cpp
@@ -256,7 +256,10 @@ void MediaPlayer::setBuffer(QIODevice* newBuffer)
 {
     if (m_buffer.get() == newBuffer)
         return;
-    m_buffer.reset(newBuffer);
+
+    m_buffer.reset(newBuffer, [](QObject*){}); // NoDeleter
+                                               // RAW pointer is owned by the QML engine
+                                               // and deleted outside of the shared pointer
 
     QSharedPointer<QAVIODevice> dev(new QAVIODevice(m_buffer));
 


### PR DESCRIPTION
Fixes #838, Fixes #840 

Snapshot https://mediaarea.net/download/snapshots/binary/dvrescue-gui/20240406-2/dvrescue_GUI_22.12.20240406_Mac.dmg