### PR TITLE
drop simultaneous scc and xml during capture

### DIFF
--- a/Source/GUI/dvrescue/dvrescue/DvRescueCLI.qml
+++ b/Source/GUI/dvrescue/dvrescue/DvRescueCLI.qml
@@ -285,7 +285,7 @@ Item {
             var xml = file + ".dvrescue.xml"
             var scc = file + ".scc"
 
-            var arguments = ['-y', 'device://' + id].concat(opts).concat(['-x', xml, '-c', scc, '--cc-format', 'scc', '-m', file, '--merge-output-speed', '--merge-output-concealed', '-m', '-', '--verbosity', '9', '--csv'])
+            var arguments = ['-y', 'device://' + id].concat(opts).concat(['-m', file, '--merge-output-speed', '--merge-output-concealed', '-m', '-', '--verbosity', '9', '--csv'])
 
             if(settings.endTheCaptureIftheTapeContainsNoDataFor && settings.endTheCaptureIftheTapeContainsNoDataFor !== '') {
                 arguments.push('--timeout')


### PR DESCRIPTION
workaround until https://github.com/mipops/dvrescue/issues/811 is resolved, else there's a chance that the xml and scc are out of sync with the output