### PR TITLE
fix: dvplay fails when only provided an input file

### DIFF
--- a/tools/dvplay
+++ b/tools/dvplay
@@ -525,6 +525,7 @@ fi
 }
 
 _play_dv(){
+    _get_filters
     if [[ "${BITSTREAM_FILTER_METHOD}" == "ffmpeg" ]] ; then
         "${FFMPEG_PATH}" "${INPUT_OPTS[@]}" -i "${1}" -bsf dv_error_marker -c:v copy -f rawvideo - | \
         "${FFPLAY_PATH}" - -vf "${FILTER}"


### PR DESCRIPTION
Previously, calling dvplay with only an input file, e.g.
    dvplay example_file.dv
would cause dvplay to call
    ffplay - -vf "${FILTER}"
with `${FILTER}` unset, leading to an error from ffplay.

This commit ensures that `${FILTER}` is set properly before calling ffplay.

Resolves: gh-972