### PR TITLE
feat: allow setting `dvplay`/`dvsampler` font via envvar

### DIFF
--- a/tools/dvplay
+++ b/tools/dvplay
@@ -430,7 +430,9 @@ _get_iso8601(){
 }
 
 # font selection
-if [[ -f "/Library/Fonts/Andale Mono.ttf" ]] ; then
+if [[ -n "${DVRESCUE_FONT}" ]] ; then
+    DEFAULTFONT="${DVRESCUE_FONT}"
+elif [[ -f "/Library/Fonts/Andale Mono.ttf" ]] ; then
     DEFAULTFONT="/Library/Fonts/Andale Mono.ttf"
 elif [[ -f "/System/Library/Fonts/Supplemental/Andale Mono.ttf" ]] ; then
     DEFAULTFONT="/System/Library/Fonts/Supplemental/Andale Mono.ttf"

--- a/tools/dvsampler
+++ b/tools/dvsampler
@@ -28,7 +28,9 @@ _report(){
 
 outputdir="samples"
 
-if [[ -f "/Library/Fonts/Andale Mono.ttf" ]] ; then
+if [[ -n "${DVRESCUE_FONT}" ]] ; then
+  DEFAULTFONT="${DVRESCUE_FONT}"
+elif [[ -f "/Library/Fonts/Andale Mono.ttf" ]] ; then
   DEFAULTFONT="/Library/Fonts/Andale Mono.ttf"
 elif [[ -f "/System/Library/Fonts/Supplemental/Andale Mono.ttf" ]] ; then
   DEFAULTFONT="/System/Library/Fonts/Supplemental/Andale Mono.ttf"


### PR DESCRIPTION
This PR allows the environment variable `DVRESCUE_FONT` to set the font used by `dvplay` and `dvsampler`. This allows the font used to be configured by the user, and also allows a font to be provided so that the scripts can function properly when none of the hardcoded fonts could be found successfully.

Related-to: gh-974