### PR TITLE
fix(dvsampler): use Liberation font on Linux

### DIFF
--- a/tools/dvsampler
+++ b/tools/dvsampler
@@ -38,6 +38,9 @@ elif [[ -f "/Library/Fonts/Microsoft/Lucida Console.ttf" ]] ; then
   DEFAULTFONT="/Library/Fonts/Microsoft/Lucida\Console.ttf"
 elif [[ -f "/Library/Fonts/LetterGothicStd.otf" ]] ; then
   DEFAULTFONT="/Library/Fonts/LetterGothicStd.otf"
+elif [[ -f "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf" ]] ; then
+  DEFAULTFONT="/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf"
+else
 else
   _report -wt "$(basename "${0}") can't find a preferred font to use, please report this error to https://github.com/mipops/dvrescue/issues"
 fi


### PR DESCRIPTION
Previously, `dvsampler` would not find a font to use when run on Linux. While `dvplay` additionally searched for the Liberation font on Linux, `dvsampler` did not.
This commit makes `dvsampler` also fallback to the Liberation font on Linux.

Resolves: gh-974