### PR TITLE
fix: unmark scripts as binary files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,9 @@
-dvgraph binary
-dvloupe binary
-dvmap binary
-dvpackager binary
-dvplay binary
-dvsampler binary
-dvloupe.sh binary
-dvplay.sh binary
-dvrescue.sh binary
-ffmpeg.sh binary
-mediainfo.sh binary
-xml.sh binary
+# Prevent bash scripts from being checked out with
+# CRLF line endings on Windows
+dvgraph text eol=lf
+dvloupe text eol=lf
+dvmap text eol=lf
+dvpackager text eol=lf
+dvplay text eol=lf
+dvsampler text eol=lf
+*.sh text eol=lf


### PR DESCRIPTION
This is an alternative to PR #977
***
The current `.gitattributes` file marks all bash scripts as binary files, which prevents most `git` commands like `git diff` from working properly unless a `--text` argument is given, and entirely breaks the default merge strategy and conflict markers during manual merges.

This was originally done to ensure bash scripts would keep their LF line-endings on Windows; however, this is better accomplished by the `text eol=lf` attributes instead. `text eol=lf` instructs git to always checkout specified text files with LF line-endings, regardless of what line-endings are considered 'native' on the current system.

This commit changes the `binary` attribute to `text eol=lf` for shell scripts, continuing to ensure they are checked out with LF line-endings on Windows, while also allowing `git` utilities like `git diff`, `git log -p`, and merges to work as expected.

Closes: gh-977